### PR TITLE
fix: Add Location header per spec and changed status code.

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -1929,8 +1929,9 @@ app.post('/:type/:id',
       pq.add(activity.distribute(addressees))
       const output = await activity.expanded()
       output['@context'] = output['@context'] || CONTEXT
-      res.status(200)
+      res.status(201)
       res.set('Content-Type', 'application/activity+json')
+      res.set('Location', await activity.id())
       res.json(output)
     } else if (full === await owner.prop('inbox')) { // remote delivery
       if (!req.auth?.subject) {


### PR DESCRIPTION
Based on:
> Section 6. Servers MUST return a 201 Created HTTP code, and unless the activity is transient, MUST include the new id in the Location header.

Closes #89
