### PR TITLE
fix: Check for all variants of the Public address

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -34,6 +34,7 @@ const PENDING_CONTEXT = 'https://purl.archive.org/socialweb/pending'
 const CONTEXT = [AS_CONTEXT, SEC_CONTEXT, BLOCKED_CONTEXT, PENDING_CONTEXT]
 
 const PUBLIC = 'https://www.w3.org/ns/activitystreams#Public'
+const PUBLICS = [PUBLIC, "as:Public", "Public"]
 const PUBLIC_OBJ = { id: PUBLIC, nameMap: { en: 'Public' }, type: 'Collection' }
 const MAX_PAGE_SIZE = 20
 
@@ -399,10 +400,14 @@ class ActivityObject {
         return false
       }
     }
+
     // anyone can read if it's public
-    if (addresseeIds.includes(PUBLIC)) {
-      return true
+    for (const addresseeId of addresseeIds) {
+      if (PUBLICS.includes(addresseeId)) {
+        return true
+      }
     }
+
     // otherwise, unauthenticated can't read
     if (!subject) {
       return false
@@ -1093,7 +1098,9 @@ class Activity extends ActivityObject {
     }
 
     for (const addressee of expanded) {
-      pq.add(sendTo(addressee))
+      if (!PUBLICS.includes(addressee)) {
+        pq.add(sendTo(addressee))
+      }
     }
   }
 }


### PR DESCRIPTION
Base on the note in the AP spec:
> Compacting an ActivityStreams object using the ActivityStreams JSON-LD context might result in https://www.w3.org/ns/activitystreams#Public being represented as simply Public or as:Public which are valid representations of the Public collection. Implementations which treat ActivityStreams objects as simply JSON rather than converting an incoming activity over to a local context using JSON-LD tooling should be aware of this and should be prepared to accept all three representations.

This is a "should" so I don't know if this PR is really a "fix" or just an interoperability improvement.

Closes #90.