### PR TITLE
fix: tests fail after first run when using a persistent database

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -25,7 +25,7 @@ import { tmpdir } from 'os'
 
 // Configuration
 
-const DATABASE = process.env.OPP_DATABASE || ':memory:'
+const DATABASE = process.env.OPP_DATABASE || 'onepage.pub.db'
 const HOSTNAME = process.env.OPP_HOSTNAME || 'localhost'
 const PORT = process.env.OPP_PORT || 65380
 const KEY = process.env.OPP_KEY || 'localhost.key'

--- a/index.test.mjs
+++ b/index.test.mjs
@@ -10,6 +10,7 @@ import { promisify } from 'node:util'
 import { Blob } from 'node:buffer'
 
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0
+process.env.OPP_DATABASE = ':memory:'
 
 const MAIN_PORT = 50941 // V
 const REMOTE_PORT = 51996 // Cr


### PR DESCRIPTION
Creates a persistent database and sets it as the default but uses the non persistent in memory database for testing.