### PR TITLE
fix: tests fail if default value of INVITE_CODE is set

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -24,6 +24,7 @@ import path from 'path'
 import { tmpdir } from 'os'
 
 // Configuration
+process.env.OPP_INVITE_CODE = 'test-invite-code'
 
 const DATABASE = process.env.OPP_DATABASE || ':memory:'
 const HOSTNAME = process.env.OPP_HOSTNAME || 'localhost'
@@ -32,7 +33,7 @@ const KEY = process.env.OPP_KEY || 'localhost.key'
 const CERT = process.env.OPP_CERT || 'localhost.crt'
 const LOG_LEVEL = process.env.OPP_LOG_LEVEL || 'warn'
 const SESSION_SECRET = process.env.OPP_SESSION_SECRET || 'insecure-session-secret'
-const INVITE_CODE = process.env.OPP_INVITE_CODE || null
+const INVITE_CODE = process.env.OPP_INVITE_CODE || ""
 const BLOCK_LIST = process.env.OPP_BLOCK_LIST || null
 const ORIGIN = process.env.OPP_ORIGIN || ((PORT === 443) ? `https://${HOSTNAME}` : `https://${HOSTNAME}:${PORT}`)
 const NAME = process.env.OPP_NAME || (new URL(ORIGIN)).hostname

--- a/index.test.mjs
+++ b/index.test.mjs
@@ -10,6 +10,7 @@ import { promisify } from 'node:util'
 import { Blob } from 'node:buffer'
 
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0
+process.env.OPP_INVITE_CODE = 'test-invite-code'
 
 const MAIN_PORT = 50941 // V
 const REMOTE_PORT = 51996 // Cr
@@ -24,6 +25,7 @@ const AS2 = 'application/ld+json; profile="https://www.w3.org/ns/activitystreams
 const AS2_CONTEXT = 'https://www.w3.org/ns/activitystreams'
 const AS2_MEDIA_TYPE = 'application/activity+json; charset=utf-8'
 const PUBLIC = 'https://www.w3.org/ns/activitystreams#Public'
+const INVITE_CODE = process.env.OPP_INVITE_CODE || ""
 
 const generateKeyPair = promisify(crypto.generateKeyPair)
 
@@ -97,13 +99,15 @@ const registerUser = (() => {
     i++
     const username = `testuser${i}`
     const password = `testpassword${i}`
+    const invitecode = INVITE_CODE
     const reg = await fetch(`https://localhost:${port}/register`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       body: querystring.stringify({
         username,
         password,
-        confirmation: password
+        confirmation: password,
+        invitecode
       })
     })
     const text = await reg.text()
@@ -389,13 +393,15 @@ describe('onepage.pub', { only: true }, () => {
     it('can register a user', async () => {
       const username = 'testuser1'
       const password = 'testpassword1'
+      const invitecode = INVITE_CODE
       const res = await fetch(`https://localhost:${MAIN_PORT}/register`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         body: querystring.stringify({
           username,
           password,
-          confirmation: password
+          confirmation: password,
+          invitecode
         })
       })
       const body = await res.text()
@@ -3309,13 +3315,15 @@ describe('onepage.pub', { only: true }, () => {
     it('can get cookie from registration', async () => {
       const username = 'testregcookie'
       const password = 'testregcookiepass'
+      const invitecode = INVITE_CODE
       const reg = await fetch(`https://localhost:${MAIN_PORT}/register`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         body: querystring.stringify({
           username,
           password,
-          confirmation: password
+          confirmation: password,
+          invitecode
         })
       })
       const text = await reg.text()
@@ -3745,13 +3753,15 @@ describe('onepage.pub', { only: true }, () => {
     it('bootstrap in registration results', async () => {
       const username = 'testbootstrap'
       const password = 'testbootstrap'
+      const invitecode = INVITE_CODE
       const res = await fetch(`https://localhost:${MAIN_PORT}/register`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         body: querystring.stringify({
           username,
           password,
-          confirmation: password
+          confirmation: password,
+          invitecode
         })
       })
       const body = await res.text()
@@ -4110,7 +4120,7 @@ describe('onepage.pub', { only: true }, () => {
   })
 
   describe('Invitation code', () => {
-    const CODE = 'icky-serving-18750'
+    const CODE = INVITE_CODE
     let server = null
     before(async () => {
       server = await startServer(THIRD_PORT, { OPP_INVITE_CODE: CODE })
@@ -4377,13 +4387,15 @@ describe('onepage.pub', { only: true }, () => {
     it('can register a user', async () => {
       const username = 'proxyuser1'
       const password = 'proxypassword1'
+      const invitecode = INVITE_CODE
       const reg = await fetch(`http://localhost:${THIRD_PORT}/register`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         body: querystring.stringify({
           username,
           password,
-          confirmation: password
+          confirmation: password,
+          invitecode
         })
       })
       const text = await reg.text()


### PR DESCRIPTION
sets an `INVITE_CODE` default value.
changes `null` to an empty string `""`.
adds `process.env.OPP_INVITE_CODE `to **index.test.mjs**
adds `INVITE_CODE` constant to the tests and applies it where needed.